### PR TITLE
[Feature] Add Zoom-On-Select, Move CSS Styles out of JS

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -43,3 +43,10 @@ button {
   stroke: grey;
   stroke-width: 1px;
 }
+
+/* Map Styles */
+path.stateBorder {
+  fill: none;
+  stroke: #fff;
+  stroke-linejoin: 'round';
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,7 +10,7 @@ import MedianLine from "../components/MedianLine";
 import { Description, GraphDescription, Title } from "../components/Meta";
 import Preloader from "../components/Preloader";
 
-import { ICountyName, ICountyValue, IFilter, ISalary }from '../interfaces';
+import { ICountyName, ICountyValue, IFilter, ISalary, IStateName }from '../interfaces';
 
 import USStatesMap from "../components/Meta/USStatesMap";
 import { valueAccessor } from '../utils';
@@ -26,6 +26,7 @@ interface IMedian {
   readonly medianIncome: number;
 }
 
+
 type filterFunctionType = (d: ISalary) => boolean;
 
 
@@ -36,7 +37,7 @@ interface IState {
   techSalaries: ISalary[];
   salariesFilter: (d: any) => boolean;
   countyNames: ICountyName[]; // name, id
-  USstateNames: object[],
+  USstateNames: IStateName[],
   usTopoJson: topojson.UsAtlas | null,
   filteredBy: IFilter,
 };

--- a/src/components/CountyMap/County.tsx
+++ b/src/components/CountyMap/County.tsx
@@ -38,15 +38,13 @@ class County extends Component<IProps, object> {
   public render() {
     const { value, geoPath, feature, quantize } = this.props;
 
-    let color = BlankColor;
-    if (value) {
-      color = ChoroplethColors[quantize(value)];
-    }
+    const color = value ? ChoroplethColors[quantize(value)]: BlankColor;
   
     const featurePath = geoPath(feature);
     if (!featurePath) {
       return null
     }  
+
     return (
       <path
         d={featurePath}

--- a/src/interfaces.tsx
+++ b/src/interfaces.tsx
@@ -9,6 +9,7 @@ interface ICountyName {
   readonly name: string;
 };
 
+// h1bs-2012-2016.csv
 interface ISalary {
   readonly base_salary: number;
   readonly submit_date: Date;
@@ -18,6 +19,13 @@ interface ISalary {
   readonly city: string;
 }
 
+// us-state-names.tsv
+interface IStateName {
+  readonly id: string;  // number as string
+  readonly code: string; // 2 letter abbreviation
+  readonly name: string;
+}
+
 // Used for interactions
 interface IFilter {
   USstate: string;
@@ -25,4 +33,4 @@ interface IFilter {
   jobTitle: string;
 }
 
-export { ICountyValue, ICountyName, IFilter, ISalary };
+export { ICountyValue, ICountyName, IFilter, ISalary, IStateName };


### PR DESCRIPTION
- Looks like I missed a feature on the first pass through the tutorial! This lets you zoom into a state when that state is selected with the controller buttons.
- Some visual properties don't get recomputed, so there's no point in having them left behind in CSS