### PR TITLE
Create better user experience for missing data combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
+### 0.6.0 2018-06-02
 
+- Add zoom-on-filter capabilities[#2](https://github.com/hydrosquall/h1b-software-salaries-ts/pull/2)
+- Improve user experience for filter combinations with missing data [#3](https://github.com/hydrosquall/h1b-software-salaries-ts/pull/3)
 
+### 0.5.0 2018-06-02
 
-### 0.5.0
-
-- Fix [bug](https://github.com/Swizec/react-d3js-step-by-step/issues/2) where adding/removing multiple filters leads to app not working
+- Fix [bug](https://github.com/Swizec/react-d3js-step-by-step/issues/2) where adding/removing multiple filters leads to app not working (Fix [#1](https://github.com/hydrosquall/h1b-software-salaries-ts/pull/1))
 - Hoist data filtering logic up to `App.jsx`
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h1b-software-salaries-ts",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "private": true,
   "homepage": "https://hydrosquall.github.io/h1b-software-salaries-ts",
   "dependencies": {

--- a/src/components/Meta/Title.tsx
+++ b/src/components/Meta/Title.tsx
@@ -17,7 +17,7 @@ class Title extends Component<IProps> {
 
   get stateFragment() {
     const USstate = this.props.filteredBy.USstate;
-    return USstate === "*" ? "" : USStatesMap[USstate.toUpperCase()];
+    return USstate === "*" ? "" : ` ${USStatesMap[USstate.toUpperCase()]}`;
   }
 
   get jobTitleFragment () {
@@ -27,11 +27,11 @@ class Title extends Component<IProps> {
     if (jobTitle === '*') {
       title = "The average H1B in tech";
       const verb = (year === "*") ? "pays" : "paid";
-      title = `${title} ${verb}`;
+      title = `${title} ${verb} `;
     } else {
       title = `Software ${jobTitle}s on an H1B`;
       const verb = (year === '*') ? 'make' : 'made';
-      title = `${title} ${verb}`
+      title = `${title} ${verb} `
     }
 
     return title;
@@ -48,7 +48,8 @@ class Title extends Component<IProps> {
   public render() {
     const mean = this.format(d3.mean(this.props.data, valueAccessor) as number);
     const hasYearAndState = this.yearsFragment && this.stateFragment;
-    const title = hasYearAndState ?
+  
+    let title = hasYearAndState ?
       (
         <h2>
           In {this.stateFragment}, {this.jobTitleFragment}
@@ -56,11 +57,20 @@ class Title extends Component<IProps> {
         </h2>
       ) : ( // Either year or state are blank
       <h2>
-          {this.jobTitleFragment} ${mean}/year
-          {this.stateFragment ? `in   ${this.stateFragment}` : ""} 
+          {this.jobTitleFragment} ${mean}/year { ` `}
+          {this.stateFragment ? `in  ${this.stateFragment}` : ""} 
           {this.yearsFragment}
         </h2>
     );
+
+    if (mean === "NaN") {
+      const { USstate, year, jobTitle } = this.props.filteredBy;
+      title = (
+        <p>
+          We don't have enough data for state: {USstate}, Job: {jobTitle}, Year: {year}. Maybe another combination will be luckier 🍀!
+        </p>
+      )
+    }
     return (
       <div className="pageHead">
         {title}


### PR DESCRIPTION
- Previously, awkward `NaNs` would appear if some combinations of filters didn't match any rows.
- This PR handles that case by providing a more helpful error message which can drive the user to try a different combination of filters.
- Also fixes some space gap issues that persisted before
- Bump version to `0.6.0`